### PR TITLE
EASY-1311: Add 'archive' element to the 'applicationspecific' element

### DIFF
--- a/src/main/config/EmdArchive-binding.xml
+++ b/src/main/config/EmdArchive-binding.xml
@@ -18,19 +18,13 @@
 -->
 <binding>
 
-	<mapping class="nl.knaw.dans.pf.language.emd.types.ApplicationSpecific" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
-		abstract="true">
+	<mapping name="archive" class="nl.knaw.dans.pf.language.emd.types.EmdArchive" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+			 abstract="true">
 
 		<namespace uri="http://www.w3.org/XML/1998/namespace" prefix="xml" />
 		<namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />
 
-		<value ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="metadataformat" field="metadataFormat" usage="optional" />
-		<value ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="pakbon-status" field="pakbonStatus" usage="optional" />
-
-
-		<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" type="nl.knaw.dans.pf.language.emd.types.EmdArchive" name="archive" field="archive" usage="optional">
-			<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="location" field="location" usage="optional"/>
-		</structure>
+		<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="location" field="location" usage="optional"/>
 
 	</mapping>
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/ApplicationSpecific.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/ApplicationSpecific.java
@@ -32,6 +32,7 @@ public class ApplicationSpecific implements Serializable {
 
     private MetadataFormat metadataFormat = MetadataFormat.DEFAULT;
     private PakbonStatus pakbonStatus = PakbonStatus.NOT_IMPORTED;
+    private EmdArchive archive;
 
     public MetadataFormat getMetadataFormat() {
         return metadataFormat;
@@ -53,4 +54,11 @@ public class ApplicationSpecific implements Serializable {
         return MetadataFormat.valueOf(name.toUpperCase());
     }
 
+    public EmdArchive getArchive() {
+        return archive;
+    }
+
+    public void setArchive(EmdArchive archive) {
+        this.archive = archive;
+    }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/EmdArchive.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/EmdArchive.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.pf.language.emd.types;
+
+import java.io.Serializable;
+
+/**
+ * Contains information about the way the dataset is archiving Created by paulboon on 07/08/2017.
+ */
+public class EmdArchive implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    // denotes where the dataset is archived.
+    public enum Location {
+        EASY, // data and metadata are archived in EASY
+        DATAVAULT; // data and metadata are archived in the DATAVAULT. there may be dissemination copies in EASY
+        public static final Location DEFAULT = EASY;
+    }
+
+    private Location location = Location.DEFAULT;
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+}

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2016/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataImplJiBXTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataImplJiBXTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 
 import nl.knaw.dans.pf.language.emd.binding.EmdMarshaller;
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller;
+import nl.knaw.dans.pf.language.emd.types.ApplicationSpecific;
 import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
+import nl.knaw.dans.pf.language.emd.types.EmdArchive;
 import nl.knaw.dans.pf.language.emd.types.EmdConstants;
 import nl.knaw.dans.pf.language.emd.validation.EMDValidator;
 import nl.knaw.dans.pf.language.xml.validation.XMLErrorHandler;
@@ -71,6 +73,23 @@ public class EasyMetadataImplJiBXTest {
 
         XMLErrorHandler handler = EMDValidator.instance().validate(xmlString, null);
         assertTrue(handler.passed());
+    }
+
+    @Test
+    public void testApplicationSpecific() throws Exception {
+        EasyMetadata emd = new EasyMetadataImpl();
+        EmdOther emdOther = emd.getEmdOther();
+
+        ApplicationSpecific easApplicationSpecific = emdOther.getEasApplicationSpecific();
+        easApplicationSpecific.setPakbonStatus(ApplicationSpecific.PakbonStatus.IMPORTED);
+
+        EmdArchive archive = new EmdArchive();
+        archive.setLocation(EmdArchive.Location.DATAVAULT);
+        easApplicationSpecific.setArchive(archive);
+
+        byte[] bytes = new EmdMarshaller(emd).getXmlByteArray();
+        EasyMetadata emd2 = new EmdUnmarshaller<EasyMetadata>(EasyMetadataImpl.class).unmarshal(bytes);
+        assertEquals(EmdArchive.Location.DATAVAULT, emd2.getEmdOther().getEasApplicationSpecific().getArchive().getLocation());
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataValidatorTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataValidatorTest.java
@@ -56,7 +56,7 @@ public class EasyMetadataValidatorTest {
         try {
             fis = new FileInputStream(VALID_XML);
             XMLErrorHandler result = EMDValidator.instance().validate(fis, EMDValidator.VERSION_0_1);
-            Assert.assertTrue(result.passed());
+            Assert.assertTrue(result.getMessages(), result.passed());
         }
         finally {
             if (fis != null) {

--- a/src/test/resources/example1.xml
+++ b/src/test/resources/example1.xml
@@ -4,7 +4,7 @@
  xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
  xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://easy.dans.knaw.nl/easy/easymetadata/ http://easy.dans.knaw.nl/schemas/md/emd/2016/emd.xsd" emd:version="version0">
+ xsi:schemaLocation="http://easy.dans.knaw.nl/easy/easymetadata/ http://easy.dans.knaw.nl/schemas/md/emd/2017/emd.xsd" emd:version="version0">
     <emd:title>
         <dc:title eas:scheme="scheme0" xml:lang="en-US" eas:schemeId="schemeId0">title0</dc:title>
         <dc:title eas:scheme="scheme1" xml:lang="en-US" eas:schemeId="schemeId1">title1</dc:title>

--- a/src/test/resources/xml-validator/valid-emd.xml
+++ b/src/test/resources/xml-validator/valid-emd.xml
@@ -329,5 +329,11 @@
     <emd:other>
         <eas:remark xml:lang="nl-NL" eas:scheme="REM0" eas:author="Author von Bar">remarks 0</eas:remark>
         <eas:remark xml:lang="nl-NL" eas:scheme="REM1" eas:author="Author von Bar">remarks 1</eas:remark>
+        <eas:application-specific>
+            <eas:metadataformat>ANY_DISCIPLINE</eas:metadataformat>
+            <eas:pakbon-status>IMPORTED</eas:pakbon-status>
+            <eas:archive eas:location="DATAVAULT"/>
+        </eas:application-specific>
+        <eas:etc>Can pass anything here</eas:etc>
     </emd:other>
 </emd:easymetadata>


### PR DESCRIPTION
fixes EASY-1311: Add 'archive' element to the 'applicationspecific' element

#### When applied it will
* Work with the new 2017 end schemas and have an optional EmdArchive element in the ApplicationSpecific element

#### Where should the reviewer @DANS-KNAW/easy start?
src/main/java/nl/knaw/dans/pf/language/emd/types/EmdArchive.java

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-schema                     | [PR#33](https://github.com/DANS-KNAW/easy-schema/pull/33)     | 