### PR TITLE
EASY-1339 Polygon classes in EMD marshaller

### DIFF
--- a/src/main/config/Spatial-binding.xml
+++ b/src/main/config/Spatial-binding.xml
@@ -41,26 +41,27 @@
 			<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="south" field="south" usage="optional"/>
 			<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="west" field="west" usage="optional"/>
 		</structure>
-        <!--<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon" field="polygon" usage="optional">-->
-            <!--<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme" field="scheme" usage="optional"/>-->
-            <!--<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="schemeId" field="schemeId" usage="optional"/>-->
-            <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="exterior" field="exterior"/>-->
-            <!--<collection style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="interior" field="interior" item-type="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPart"/>-->
-        <!--</structure>-->
+        <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon" field="polygon" usage="optional">
+            <value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme" field="scheme" usage="optional"/>
+            <value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="schemeId" field="schemeId" usage="optional"/>
+            <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-exterior" field="exterior" type="nl.knaw.dans.pf.language.emd.types.PolygonPart" usage="optional"/>
+            <collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-interior" field="interior" factory="nl.knaw.dans.pf.language.emd.types.ListFactory.polygonPartList" usage="optional">
+                <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" type="nl.knaw.dans.pf.language.emd.types.PolygonPart" usage="optional"/>
+            </collection>
+        </structure>
 	</mapping>
 
-    <!--<mapping class="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPoint" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/">-->
-        <!--<namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />-->
-        <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="x" field="x"/>-->
-        <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="y" field="y"/>-->
-    <!--</mapping>-->
+    <mapping class="nl.knaw.dans.pf.language.emd.types.PolygonPoint" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" abstract="true">
+        <namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />
+        <value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="x" field="x" usage="optional"/>
+        <value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="y" field="y" usage="optional"/>
+    </mapping>
 
-    <!--<mapping class="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPart" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/">-->
-        <!--<namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />-->
-        <!--<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="place" field="place"/>-->
-        <!--<collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="point" field="point" item-type="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPoint"/>-->
-    <!--</mapping>-->
-
-
-
+    <mapping class="nl.knaw.dans.pf.language.emd.types.PolygonPart" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" abstract="true">
+        <namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />
+        <value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="place" field="place" usage="optional"/>
+        <collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" field="points" factory="nl.knaw.dans.pf.language.emd.types.ListFactory.polygonPointList">
+            <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-point" type="nl.knaw.dans.pf.language.emd.types.PolygonPoint" usage="optional"/>
+        </collection>
+    </mapping>
 </binding>

--- a/src/main/config/Spatial-binding.xml
+++ b/src/main/config/Spatial-binding.xml
@@ -41,7 +41,26 @@
 			<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="south" field="south" usage="optional"/>
 			<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="west" field="west" usage="optional"/>
 		</structure>
-
+        <!--<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon" field="polygon" usage="optional">-->
+            <!--<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme" field="scheme" usage="optional"/>-->
+            <!--<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="schemeId" field="schemeId" usage="optional"/>-->
+            <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="exterior" field="exterior"/>-->
+            <!--<collection style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="interior" field="interior" item-type="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPart"/>-->
+        <!--</structure>-->
 	</mapping>
+
+    <!--<mapping class="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPoint" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/">-->
+        <!--<namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />-->
+        <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="x" field="x"/>-->
+        <!--<value style="element" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="y" field="y"/>-->
+    <!--</mapping>-->
+
+    <!--<mapping class="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPart" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/">-->
+        <!--<namespace uri="http://easy.dans.knaw.nl/easy/easymetadata/eas/" prefix="eas" />-->
+        <!--<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="place" field="place"/>-->
+        <!--<collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="point" field="point" item-type="nl.knaw.dans.pf.language.emd.types.Spatial.PolygonPoint"/>-->
+    <!--</mapping>-->
+
+
 
 </binding>

--- a/src/main/java/nl/knaw/dans/pf/language/emd/EmdCoverage.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/EmdCoverage.java
@@ -34,11 +34,9 @@ public class EmdCoverage extends AbstractEmdContainer {
     /**
      * Terms contained.
      */
-    static final Term[] TERMS = {
-        new Term(Term.Name.COVERAGE, Term.Namespace.DC, BasicString.class),
-        new Term(Term.Name.SPATIAL, Term.Namespace.DCTERMS, BasicString.class),
-        new Term(Term.Name.TEMPORAL, Term.Namespace.DCTERMS, BasicString.class),
-        new Term(Term.Name.SPATIAL, Term.Namespace.EAS, Spatial.class)};
+    static final Term[] TERMS = {new Term(Term.Name.COVERAGE, Term.Namespace.DC, BasicString.class),
+            new Term(Term.Name.SPATIAL, Term.Namespace.DCTERMS, BasicString.class), new Term(Term.Name.TEMPORAL, Term.Namespace.DCTERMS, BasicString.class),
+            new Term(Term.Name.SPATIAL, Term.Namespace.EAS, Spatial.class)};
 
     /**
      *

--- a/src/main/java/nl/knaw/dans/pf/language/emd/EmdCoverage.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/EmdCoverage.java
@@ -34,9 +34,11 @@ public class EmdCoverage extends AbstractEmdContainer {
     /**
      * Terms contained.
      */
-    static final Term[] TERMS = {new Term(Term.Name.COVERAGE, Term.Namespace.DC, BasicString.class),
-            new Term(Term.Name.SPATIAL, Term.Namespace.DCTERMS, BasicString.class), new Term(Term.Name.TEMPORAL, Term.Namespace.DCTERMS, BasicString.class),
-            new Term(Term.Name.SPATIAL, Term.Namespace.EAS, Spatial.class)};
+    static final Term[] TERMS = {
+        new Term(Term.Name.COVERAGE, Term.Namespace.DC, BasicString.class),
+        new Term(Term.Name.SPATIAL, Term.Namespace.DCTERMS, BasicString.class),
+        new Term(Term.Name.TEMPORAL, Term.Namespace.DCTERMS, BasicString.class),
+        new Term(Term.Name.SPATIAL, Term.Namespace.EAS, Spatial.class)};
 
     /**
      *

--- a/src/main/java/nl/knaw/dans/pf/language/emd/EmdRights.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/EmdRights.java
@@ -39,13 +39,17 @@ public class EmdRights extends AbstractEmdContainer {
     /**
      * Terms contained.
      */
-    static final Term[] TERMS = {new Term(Term.Name.RIGHTS, Term.Namespace.DC, BasicString.class),
-            new Term(Term.Name.ACCESSRIGHTS, Term.Namespace.DCTERMS, BasicString.class),
-            new Term(Term.Name.LICENSE, Term.Namespace.DCTERMS, BasicString.class), new Term(Term.Name.RIGHTSHOLDER, Term.Namespace.DCTERMS, BasicString.class)};
+    static final Term[] TERMS = {
+        new Term(Term.Name.RIGHTS, Term.Namespace.DC, BasicString.class),
+        new Term(Term.Name.ACCESSRIGHTS, Term.Namespace.DCTERMS, BasicString.class),
+        new Term(Term.Name.LICENSE, Term.Namespace.DCTERMS, BasicString.class),
+        new Term(Term.Name.RIGHTSHOLDER, Term.Namespace.DCTERMS, BasicString.class)
+    };
 
     public static final String RIGHTS = "";
     public static final String ACCESS_RIGHTS = "accessRights";
     public static final String LICENSE = "license";
+    public static final String RIGHTSHOLDER = "rightsholder";
 
     public static final String LICENSE_ACCEPT = "accept";
     public static final String SCHEME_LICENSE_ACCEPT_E2V1 = "Easy2 version 1";
@@ -72,11 +76,12 @@ public class EmdRights extends AbstractEmdContainer {
         map.put(RIGHTS, this.getDcRights());
         map.put(ACCESS_RIGHTS, this.getTermsAccessRights());
         map.put(LICENSE, this.getTermsLicense());
+        map.put(RIGHTSHOLDER, this.getTermsRightsHolder());
 
         return map;
     }
 
-    public static final String[] LIST_KEYS = {RIGHTS, ACCESS_RIGHTS, LICENSE};
+    public static final String[] LIST_KEYS = {RIGHTS, ACCESS_RIGHTS, LICENSE, RIGHTSHOLDER};
 
     /**
      * {@inheritDoc}

--- a/src/main/java/nl/knaw/dans/pf/language/emd/EmdRights.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/EmdRights.java
@@ -39,12 +39,9 @@ public class EmdRights extends AbstractEmdContainer {
     /**
      * Terms contained.
      */
-    static final Term[] TERMS = {
-        new Term(Term.Name.RIGHTS, Term.Namespace.DC, BasicString.class),
-        new Term(Term.Name.ACCESSRIGHTS, Term.Namespace.DCTERMS, BasicString.class),
-        new Term(Term.Name.LICENSE, Term.Namespace.DCTERMS, BasicString.class),
-        new Term(Term.Name.RIGHTSHOLDER, Term.Namespace.DCTERMS, BasicString.class)
-    };
+    static final Term[] TERMS = {new Term(Term.Name.RIGHTS, Term.Namespace.DC, BasicString.class),
+            new Term(Term.Name.ACCESSRIGHTS, Term.Namespace.DCTERMS, BasicString.class),
+            new Term(Term.Name.LICENSE, Term.Namespace.DCTERMS, BasicString.class), new Term(Term.Name.RIGHTSHOLDER, Term.Namespace.DCTERMS, BasicString.class)};
 
     public static final String RIGHTS = "";
     public static final String ACCESS_RIGHTS = "accessRights";

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/ListFactory.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/ListFactory.java
@@ -70,4 +70,13 @@ public final class ListFactory {
         return new ArrayList<BasicRemark>();
     }
 
+    // Method used by JiBX serialization.
+    static synchronized List<PolygonPart> polygonPartList() {
+        return new ArrayList<PolygonPart>();
+    }
+
+    // Method used by JiBX serialization.
+    static synchronized List<PolygonPoint> polygonPointList() {
+        return new ArrayList<PolygonPoint>();
+    }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPart.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPart.java
@@ -1,11 +1,8 @@
 package nl.knaw.dans.pf.language.emd.types;
 
-import java.io.Serializable;
 import java.util.List;
 
-public class PolygonPart implements Serializable {
-
-    private static final long serialVersionUID = -4863048182836567384L;
+public class PolygonPart {
 
     private String place;
     private List<PolygonPoint> points;
@@ -39,6 +36,14 @@ public class PolygonPart implements Serializable {
     }
 
     public boolean isComplete() {
-        return this.place != null && this.points != null;
+        return this.place != null && this.points != null && isComplete(this.points);
+    }
+
+    private boolean isComplete(List<PolygonPoint> pps) {
+        for (PolygonPoint pp : pps) {
+            if (!pp.isComplete())
+                return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPart.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPart.java
@@ -1,0 +1,44 @@
+package nl.knaw.dans.pf.language.emd.types;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class PolygonPart implements Serializable {
+
+    private static final long serialVersionUID = -4863048182836567384L;
+
+    private String place;
+    private List<PolygonPoint> points;
+
+    public PolygonPart() {}
+
+    public PolygonPart(String place, List<PolygonPoint> points) {
+        this.place = place;
+        this.points = points;
+    }
+
+    public String getPlace() {
+        return this.place;
+    }
+
+    public void setPlace(String place) {
+        this.place = place;
+    }
+
+    public List<PolygonPoint> getPoints() {
+        return this.points;
+    }
+
+    public void setPoints(List<PolygonPoint> points) {
+        this.points = points;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(place=%s, points=%s)", this.place, this.points);
+    }
+
+    public boolean isComplete() {
+        return this.place != null && this.points != null;
+    }
+}

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPoint.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPoint.java
@@ -1,0 +1,43 @@
+package nl.knaw.dans.pf.language.emd.types;
+
+import java.io.Serializable;
+
+public class PolygonPoint implements Serializable {
+
+    private static final long serialVersionUID = -4108876677692958853L;
+
+    private String x;
+    private String y;
+
+    public PolygonPoint() {}
+
+    public PolygonPoint(String x, String y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public String getX() {
+        return this.x;
+    }
+
+    public void setX(String x) {
+        this.x = x;
+    }
+
+    public String getY() {
+        return this.y;
+    }
+
+    public void setY(String y) {
+        this.y = y;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(x=%s, y=%s)", this.x, this.y);
+    }
+
+    public boolean isComplete() {
+        return this.x != null && this.y != null;
+    }
+}

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPoint.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/PolygonPoint.java
@@ -1,10 +1,6 @@
 package nl.knaw.dans.pf.language.emd.types;
 
-import java.io.Serializable;
-
-public class PolygonPoint implements Serializable {
-
-    private static final long serialVersionUID = -4108876677692958853L;
+public class PolygonPoint {
 
     private String x;
     private String y;

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
@@ -549,7 +549,15 @@ public class Spatial implements MetadataItem {
         }
 
         public boolean isComplete() {
-            return this.exterior != null && this.interior != null;
+            return this.exterior != null && this.interior != null && this.exterior.isComplete() && isComplete(this.interior);
+        }
+
+        private boolean isComplete(List<PolygonPart> pps) {
+            for (PolygonPart pp : pps) {
+                if (!pp.isComplete())
+                    return false;
+            }
+            return true;
         }
     }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.pf.language.emd.types;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Expresses a spatial coverage.
@@ -34,6 +35,8 @@ public class Spatial implements MetadataItem {
     private Point point;
 
     private Box box;
+
+    private Polygon polygon;
 
     /**
      * Constructor.
@@ -68,6 +71,12 @@ public class Spatial implements MetadataItem {
         super();
         this.place = new BasicString(place);
         this.box = box;
+    }
+
+    public Spatial(String place, Polygon polygon) {
+      super();
+      this.place = new BasicString(place);
+      this.polygon = polygon;
     }
 
     /**
@@ -139,13 +148,23 @@ public class Spatial implements MetadataItem {
         }
     }
 
-    @Override
+  public Polygon getPolygon() {
+    return this.polygon;
+  }
+
+  public void setPolygon(Polygon polygon) {
+    this.polygon = polygon;
+  }
+
+  @Override
     public String getSchemeId() {
         // locator has schemeId in scheme instead of schemeId!
         if (point != null) {
             return point.getScheme();
         } else if (box != null) {
             return box.getScheme();
+        } else if (polygon != null) {
+          return polygon.getScheme();
         } else {
             return null;
         }
@@ -168,6 +187,9 @@ public class Spatial implements MetadataItem {
         if (box != null) {
             builder.append(box.toString());
         }
+        if (polygon != null) {
+          builder.append(polygon.toString());
+        }
         return builder.toString();
     }
 
@@ -177,6 +199,8 @@ public class Spatial implements MetadataItem {
             complete = point.isComplete();
         } else if (box != null) {
             complete = box.isComplete();
+        } else if (polygon != null) {
+            complete = polygon.isComplete();
         }
         return complete;
     }
@@ -479,4 +503,122 @@ public class Spatial implements MetadataItem {
 
     }
 
+    public static class Polygon extends Locator {
+
+      private static final long serialVersionUID = 7316626274747251053L;
+
+      private PolygonPart exterior;
+      private List<PolygonPart> interior;
+
+      public Polygon() {
+        super();
+      }
+
+      public Polygon(String scheme, PolygonPart exterior, List<PolygonPart> interior) {
+        super(scheme);
+        this.exterior = exterior;
+        this.interior = interior;
+      }
+
+      public PolygonPart getExterior() {
+        return this.exterior;
+      }
+
+      public void setExterior(PolygonPart exterior) {
+        this.exterior = exterior;
+      }
+
+      public List<PolygonPart> getInterior() {
+        return this.interior;
+      }
+
+      public void setInterior(List<PolygonPart> interior) {
+        this.interior = interior;
+      }
+
+      @Override
+      public String toString() {
+        return String.format("(exterior=%s, interior=%s)", this.exterior, this.interior);
+      }
+
+      public boolean isComplete() {
+        return this.exterior != null && this.interior != null;
+      }
+    }
+
+    public static class PolygonPart {
+
+      private String place;
+      private List<PolygonPoint> points;
+
+      public PolygonPart() {}
+
+      public PolygonPart(String place, List<PolygonPoint> points) {
+        this.place = place;
+        this.points = points;
+      }
+
+      public String getPlace() {
+        return this.place;
+      }
+
+      public void setPlace(String place) {
+        this.place = place;
+      }
+
+      public List<PolygonPoint> getPoints() {
+        return this.points;
+      }
+
+      public void setPoints(List<PolygonPoint> points) {
+        this.points = points;
+      }
+
+      @Override
+      public String toString() {
+        return String.format("(place=%s, points=%s)", this.place, this.points);
+      }
+
+      public boolean isComplete() {
+        return this.place != null && this.points != null;
+      }
+    }
+
+    public static class PolygonPoint {
+
+      private String x;
+      private String y;
+
+      public PolygonPoint() {}
+
+      public PolygonPoint(String x, String y) {
+        this.x = x;
+        this.y = y;
+      }
+
+      public String getX() {
+        return this.x;
+      }
+
+      public void setX(String x) {
+        this.x = x;
+      }
+
+      public String getY() {
+        return this.y;
+      }
+
+      public void setY(String y) {
+        this.y = y;
+      }
+
+      @Override
+      public String toString() {
+        return String.format("(x=%s, y=%s)", this.x, this.y);
+      }
+
+      public boolean isComplete() {
+        return this.x != null && this.y != null;
+      }
+    }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Spatial.java
@@ -74,9 +74,9 @@ public class Spatial implements MetadataItem {
     }
 
     public Spatial(String place, Polygon polygon) {
-      super();
-      this.place = new BasicString(place);
-      this.polygon = polygon;
+        super();
+        this.place = new BasicString(place);
+        this.polygon = polygon;
     }
 
     /**
@@ -116,8 +116,9 @@ public class Spatial implements MetadataItem {
      *         if this spatial expresses a box
      */
     public void setPoint(final Point point) throws IllegalStateException {
-        if (box != null) {
-            throw new IllegalStateException("Only one of " + Point.class.getName() + " or " + Box.class.getName() + " is acceptable.");
+        if (box != null || polygon != null) {
+            throw new IllegalStateException(String.format("Only one of %s or %s or %s is acceptable.", Point.class.getName(), Box.class.getName(),
+                    Polygon.class.getName()));
         } else {
             this.point = point;
         }
@@ -141,22 +142,28 @@ public class Spatial implements MetadataItem {
      *         if this spatial expresses a point
      */
     public void setBox(final Box box) throws IllegalStateException {
-        if (point != null) {
-            throw new IllegalStateException("Only one of " + Point.class.getName() + " or " + Box.class.getName() + " is acceptable.");
+        if (point != null || polygon != null) {
+            throw new IllegalStateException(String.format("Only one of %s or %s or %s is acceptable.", Point.class.getName(), Box.class.getName(),
+                    Polygon.class.getName()));
         } else {
             this.box = box;
         }
     }
 
-  public Polygon getPolygon() {
-    return this.polygon;
-  }
+    public Polygon getPolygon() {
+        return this.polygon;
+    }
 
-  public void setPolygon(Polygon polygon) {
-    this.polygon = polygon;
-  }
+    public void setPolygon(Polygon polygon) {
+        if (point != null || box != null) {
+            throw new IllegalStateException(String.format("Only one of %s or %s or %s is acceptable.", Point.class.getName(), Box.class.getName(),
+                    Polygon.class.getName()));
+        } else {
+            this.polygon = polygon;
+        }
+    }
 
-  @Override
+    @Override
     public String getSchemeId() {
         // locator has schemeId in scheme instead of schemeId!
         if (point != null) {
@@ -164,7 +171,7 @@ public class Spatial implements MetadataItem {
         } else if (box != null) {
             return box.getScheme();
         } else if (polygon != null) {
-          return polygon.getScheme();
+            return polygon.getScheme();
         } else {
             return null;
         }
@@ -188,7 +195,7 @@ public class Spatial implements MetadataItem {
             builder.append(box.toString());
         }
         if (polygon != null) {
-          builder.append(polygon.toString());
+            builder.append(polygon.toString());
         }
         return builder.toString();
     }
@@ -206,7 +213,7 @@ public class Spatial implements MetadataItem {
     }
 
     /**
-     * Super class for Box and Point, both having a scheme attribute.
+     * Super class for Polygon, Box and Point, all having a scheme attribute.
      * 
      * @author ecco
      */
@@ -505,120 +512,44 @@ public class Spatial implements MetadataItem {
 
     public static class Polygon extends Locator {
 
-      private static final long serialVersionUID = 7316626274747251053L;
+        private static final long serialVersionUID = 7316626274747251053L;
 
-      private PolygonPart exterior;
-      private List<PolygonPart> interior;
+        private PolygonPart exterior;
+        private List<PolygonPart> interior;
 
-      public Polygon() {
-        super();
-      }
+        public Polygon() {
+            super();
+        }
 
-      public Polygon(String scheme, PolygonPart exterior, List<PolygonPart> interior) {
-        super(scheme);
-        this.exterior = exterior;
-        this.interior = interior;
-      }
+        public Polygon(String scheme, PolygonPart exterior, List<PolygonPart> interior) {
+            super(scheme);
+            this.exterior = exterior;
+            this.interior = interior;
+        }
 
-      public PolygonPart getExterior() {
-        return this.exterior;
-      }
+        public PolygonPart getExterior() {
+            return this.exterior;
+        }
 
-      public void setExterior(PolygonPart exterior) {
-        this.exterior = exterior;
-      }
+        public void setExterior(PolygonPart exterior) {
+            this.exterior = exterior;
+        }
 
-      public List<PolygonPart> getInterior() {
-        return this.interior;
-      }
+        public List<PolygonPart> getInterior() {
+            return this.interior;
+        }
 
-      public void setInterior(List<PolygonPart> interior) {
-        this.interior = interior;
-      }
+        public void setInterior(List<PolygonPart> interior) {
+            this.interior = interior;
+        }
 
-      @Override
-      public String toString() {
-        return String.format("(exterior=%s, interior=%s)", this.exterior, this.interior);
-      }
+        @Override
+        public String toString() {
+            return String.format("(exterior=%s, interior=%s)", this.exterior, this.interior);
+        }
 
-      public boolean isComplete() {
-        return this.exterior != null && this.interior != null;
-      }
-    }
-
-    public static class PolygonPart {
-
-      private String place;
-      private List<PolygonPoint> points;
-
-      public PolygonPart() {}
-
-      public PolygonPart(String place, List<PolygonPoint> points) {
-        this.place = place;
-        this.points = points;
-      }
-
-      public String getPlace() {
-        return this.place;
-      }
-
-      public void setPlace(String place) {
-        this.place = place;
-      }
-
-      public List<PolygonPoint> getPoints() {
-        return this.points;
-      }
-
-      public void setPoints(List<PolygonPoint> points) {
-        this.points = points;
-      }
-
-      @Override
-      public String toString() {
-        return String.format("(place=%s, points=%s)", this.place, this.points);
-      }
-
-      public boolean isComplete() {
-        return this.place != null && this.points != null;
-      }
-    }
-
-    public static class PolygonPoint {
-
-      private String x;
-      private String y;
-
-      public PolygonPoint() {}
-
-      public PolygonPoint(String x, String y) {
-        this.x = x;
-        this.y = y;
-      }
-
-      public String getX() {
-        return this.x;
-      }
-
-      public void setX(String x) {
-        this.x = x;
-      }
-
-      public String getY() {
-        return this.y;
-      }
-
-      public void setY(String y) {
-        this.y = y;
-      }
-
-      @Override
-      public String toString() {
-        return String.format("(x=%s, y=%s)", this.x, this.y);
-      }
-
-      public boolean isComplete() {
-        return this.x != null && this.y != null;
-      }
+        public boolean isComplete() {
+            return this.exterior != null && this.interior != null;
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 
@@ -82,5 +82,4 @@ public final class EMDValidator extends AbstractValidator {
     public XMLErrorHandler validate(EasyMetadata emd) throws XMLException, SAXException {
         return validate(new EmdMarshaller(emd).getXmlString(), null);
     }
-
 }

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataImplTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EasyMetadataImplTest.java
@@ -63,11 +63,11 @@ public class EasyMetadataImplTest {
     @Test
     public void testToString() throws URISyntaxException {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(3, emd);
+        EmdHelper.populate(4, emd);
         String toString = emd.toString(";");
         // System.out.println(toString);
-        Assert.assertTrue(toString.startsWith("title;http://purl.org/dc/elements/1.1/;title 0;title 1;title 2"));
-        Assert.assertTrue(toString.endsWith("remarks;http://easy.dans.knaw.nl/easy/easymetadata/eas/;remarks 0;remarks 1;remarks 2"));
+        Assert.assertTrue(toString.startsWith("title;http://purl.org/dc/elements/1.1/;title 0;title 1;title 2;title 3"));
+        Assert.assertTrue(toString.endsWith("remarks;http://easy.dans.knaw.nl/easy/easymetadata/eas/;remarks 0;remarks 1;remarks 2;remarks 3"));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class EasyMetadataImplTest {
             Assert.assertTrue(values.isEmpty());
         }
 
-        EmdHelper.populate(3, (EasyMetadataImpl) emd);
+        EmdHelper.populate(4, (EasyMetadataImpl) emd);
         dc = emd.getDublinCoreMetadata();
         for (PropertyName name : PropertyName.values()) {
             List<String> values = dc.get(name);
@@ -223,5 +223,4 @@ public class EasyMetadataImplTest {
 
         // System.out.println(emd.asXMLString(4));
     }
-
 }

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.pf.language.emd;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -140,11 +142,27 @@ public class EmdHelper {
                     Spatial.Point point = new Spatial.Point("POI" + i, "123.45", "456.78");
                     point.setSchemeId("point.bla" + i);
                     spat.setPoint(point);
-                } else {
+                } else if (i % 2 == 1) {
                     // Spatial.Box box = new Spatial.Box("BOX" + i, 12.3, 23.4, 34.5, 45.6);
                     Spatial.Box box = new Spatial.Box("BOX" + i, "12.3", "23.4", "34.5", "45.6");
-                    box.setSchemeId("bax.bla" + i);
+                    box.setSchemeId("box.bla" + i);
                     spat.setBox(box);
+                } else {
+//                  Spatial.PolygonPart exterior = new Spatial.PolygonPart("main triangle",
+//                      Arrays.asList(
+//                          new Spatial.PolygonPoint("52.08110", "4.34521"),
+//                          new Spatial.PolygonPoint("52.08071", "4.34422"),
+//                          new Spatial.PolygonPoint("52.07913", "4.34332"),
+//                          new Spatial.PolygonPoint("52.08110", "4.34521")));
+//                  Spatial.PolygonPart interior1 = new Spatial.PolygonPart("main triangle",
+//                      Arrays.asList(
+//                          new Spatial.PolygonPoint("52.080542", "4.344215"),
+//                          new Spatial.PolygonPoint("52.080450", "4.344323"),
+//                          new Spatial.PolygonPoint("52.080357", "4.344110"),
+//                          new Spatial.PolygonPoint("52.080542", "4.344215")));
+//                  Spatial.Polygon polygon = new Spatial.Polygon("POLYGON" + i, exterior, Collections.singletonList(interior1));
+//                  polygon.setSchemeId("polygon.bla" + 1);
+//                  spat.setPolygon(polygon);
                 }
                 list.add(spat);
             }

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
@@ -28,6 +28,8 @@ import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
 import nl.knaw.dans.pf.language.emd.types.BasicRemark;
 import nl.knaw.dans.pf.language.emd.types.BasicString;
 import nl.knaw.dans.pf.language.emd.types.IsoDate;
+import nl.knaw.dans.pf.language.emd.types.PolygonPart;
+import nl.knaw.dans.pf.language.emd.types.PolygonPoint;
 import nl.knaw.dans.pf.language.emd.types.Relation;
 import nl.knaw.dans.pf.language.emd.types.Spatial;
 
@@ -137,32 +139,24 @@ public class EmdHelper {
             for (int i = 0; i < times; i++) {
                 Spatial spat = new Spatial();
                 spat.setPlace(getBasicString(term, i));
-                if (i % 2 == 0) {
+                if (i % 3 == 0) {
                     // Spatial.Point point = new Spatial.Point("POI" + i, 123.45, 456.78);
                     Spatial.Point point = new Spatial.Point("POI" + i, "123.45", "456.78");
                     point.setSchemeId("point.bla" + i);
                     spat.setPoint(point);
-                } else if (i % 2 == 1) {
+                } else if (i % 3 == 1) {
                     // Spatial.Box box = new Spatial.Box("BOX" + i, 12.3, 23.4, 34.5, 45.6);
                     Spatial.Box box = new Spatial.Box("BOX" + i, "12.3", "23.4", "34.5", "45.6");
                     box.setSchemeId("box.bla" + i);
                     spat.setBox(box);
                 } else {
-//                  Spatial.PolygonPart exterior = new Spatial.PolygonPart("main triangle",
-//                      Arrays.asList(
-//                          new Spatial.PolygonPoint("52.08110", "4.34521"),
-//                          new Spatial.PolygonPoint("52.08071", "4.34422"),
-//                          new Spatial.PolygonPoint("52.07913", "4.34332"),
-//                          new Spatial.PolygonPoint("52.08110", "4.34521")));
-//                  Spatial.PolygonPart interior1 = new Spatial.PolygonPart("main triangle",
-//                      Arrays.asList(
-//                          new Spatial.PolygonPoint("52.080542", "4.344215"),
-//                          new Spatial.PolygonPoint("52.080450", "4.344323"),
-//                          new Spatial.PolygonPoint("52.080357", "4.344110"),
-//                          new Spatial.PolygonPoint("52.080542", "4.344215")));
-//                  Spatial.Polygon polygon = new Spatial.Polygon("POLYGON" + i, exterior, Collections.singletonList(interior1));
-//                  polygon.setSchemeId("polygon.bla" + 1);
-//                  spat.setPolygon(polygon);
+                    PolygonPart exterior = new PolygonPart("main triangle", Arrays.asList(new PolygonPoint("52.08110", "4.34521"), new PolygonPoint("52.08071",
+                            "4.34422"), new PolygonPoint("52.07913", "4.34332"), new PolygonPoint("52.08110", "4.34521")));
+                    PolygonPart interior1 = new PolygonPart("hole1", Arrays.asList(new PolygonPoint("52.080542", "4.344215"), new PolygonPoint("52.080450",
+                            "4.344323"), new PolygonPoint("52.080357", "4.344110"), new PolygonPoint("52.080542", "4.344215")));
+                    Spatial.Polygon polygon = new Spatial.Polygon("POLYGON" + i, exterior, Collections.singletonList(interior1));
+                    polygon.setSchemeId("polygon.bla" + 1);
+                    spat.setPolygon(polygon);
                 }
                 list.add(spat);
             }
@@ -188,5 +182,4 @@ public class EmdHelper {
         bid.setSchemeId("BID.bla.foo" + i);
         return bid;
     }
-
 }

--- a/src/test/java/nl/knaw/dans/pf/language/emd/binding/MarshallerTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/binding/MarshallerTest.java
@@ -46,7 +46,7 @@ public class MarshallerTest {
     @Test
     public void marshallAndUnmarshallMethods() throws Exception {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(2, emd);
+        EmdHelper.populate(3, emd);
 
         EmdMarshaller m = new EmdMarshaller(emd);
         EmdUnmarshaller<EasyMetadata> um = new EmdUnmarshaller<EasyMetadata>(EasyMetadataImpl.class);
@@ -99,7 +99,7 @@ public class MarshallerTest {
     @Test
     public void settings() throws Exception {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(2, emd);
+        EmdHelper.populate(3, emd);
 
         EmdMarshaller m = new EmdMarshaller(emd);
         assertTrue(m.getStandalone());
@@ -133,7 +133,7 @@ public class MarshallerTest {
     @Test
     public void w3cDomDocumentSettings() throws Exception {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(2, emd);
+        EmdHelper.populate(3, emd);
 
         EmdMarshaller m = new EmdMarshaller(emd);
         assertTrue(m.getStandalone());
@@ -172,7 +172,7 @@ public class MarshallerTest {
     @Test
     public void w3cDomElementSettings() throws Exception {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(2, emd);
+        EmdHelper.populate(3, emd);
 
         EmdMarshaller m = new EmdMarshaller(emd);
         assertTrue(m.getStandalone());
@@ -233,5 +233,4 @@ public class MarshallerTest {
         JiBXMarshaller jm = new JiBXMarshaller(EmdMarshaller.BINDING_NAME, author);
         jm.getXmlString();
     }
-
 }

--- a/src/test/java/nl/knaw/dans/pf/language/emd/binding/RoundtripTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/binding/RoundtripTest.java
@@ -64,7 +64,7 @@ public class RoundtripTest {
     @Test
     public void easyMetadata() throws Exception {
         EasyMetadataImpl emd = new EasyMetadataImpl(MetadataFormat.DEFAULT);
-        EmdHelper.populate(2, emd);
+        EmdHelper.populate(3, emd);
 
         String xmlString = new EmdMarshaller(emd).getXmlString();
 
@@ -100,7 +100,7 @@ public class RoundtripTest {
     @Test
     public void emdTitle() throws Exception {
         EmdTitle bean = new EmdTitle();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -133,7 +133,7 @@ public class RoundtripTest {
     @Test
     public void emdCreator() throws Exception {
         EmdCreator bean = new EmdCreator();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -170,7 +170,7 @@ public class RoundtripTest {
     @Test
     public void emdSubject() throws Exception {
         EmdSubject bean = new EmdSubject();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -187,7 +187,7 @@ public class RoundtripTest {
     @Test
     public void emdDescription() throws Exception {
         EmdDescription bean = new EmdDescription();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -204,7 +204,7 @@ public class RoundtripTest {
     @Test
     public void emdPublisher() throws Exception {
         EmdPublisher bean = new EmdPublisher();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -221,7 +221,7 @@ public class RoundtripTest {
     @Test
     public void emdContributor() throws Exception {
         EmdContributor bean = new EmdContributor();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -238,7 +238,7 @@ public class RoundtripTest {
     @Test
     public void emdDate() throws Exception {
         EmdDate bean = new EmdDate();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -255,7 +255,7 @@ public class RoundtripTest {
     @Test
     public void emdType() throws Exception {
         EmdType bean = new EmdType();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -272,7 +272,7 @@ public class RoundtripTest {
     @Test
     public void emdFormat() throws Exception {
         EmdFormat bean = new EmdFormat();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -289,7 +289,7 @@ public class RoundtripTest {
     @Test
     public void emdIdentifier() throws Exception {
         EmdIdentifier bean = new EmdIdentifier();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -306,7 +306,7 @@ public class RoundtripTest {
     @Test
     public void emdSource() throws Exception {
         EmdSource bean = new EmdSource();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -323,7 +323,7 @@ public class RoundtripTest {
     @Test
     public void emdLanguage() throws Exception {
         EmdLanguage bean = new EmdLanguage();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -340,7 +340,7 @@ public class RoundtripTest {
     @Test
     public void emdRelation() throws Exception {
         EmdRelation bean = new EmdRelation();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -357,7 +357,7 @@ public class RoundtripTest {
     @Test
     public void emdCoverage() throws Exception {
         EmdCoverage bean = new EmdCoverage();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -374,7 +374,7 @@ public class RoundtripTest {
     @Test
     public void emdRights() throws Exception {
         EmdRights bean = new EmdRights();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -391,7 +391,7 @@ public class RoundtripTest {
     @Test
     public void emdAudience() throws Exception {
         EmdAudience bean = new EmdAudience();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -408,7 +408,7 @@ public class RoundtripTest {
     @Test
     public void emdOther() throws Exception {
         EmdOther bean = new EmdOther();
-        EmdHelper.populate(2, bean);
+        EmdHelper.populate(3, bean);
 
         String xml = new EmdMarshaller(bean).getXmlString();
 
@@ -421,5 +421,4 @@ public class RoundtripTest {
 
         assertEquals(xml, returnedXml);
     }
-
 }

--- a/src/test/resources/example1.xml
+++ b/src/test/resources/example1.xml
@@ -4,7 +4,7 @@
  xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
  xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://easy.dans.knaw.nl/easy/easymetadata/ http://easy.dans.knaw.nl/schemas/md/emd/2017/emd.xsd" emd:version="version0">
+ xsi:schemaLocation="http://easy.dans.knaw.nl/easy/easymetadata/ http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd" emd:version="version0">
     <emd:title>
         <dc:title eas:scheme="scheme0" xml:lang="en-US" eas:schemeId="schemeId0">title0</dc:title>
         <dc:title eas:scheme="scheme1" xml:lang="en-US" eas:schemeId="schemeId1">title1</dc:title>
@@ -321,6 +321,49 @@
                     <eas:south>south0</eas:south>
                     <eas:west>west0</eas:west>
                 </eas:box>
+        </eas:spatial>
+        <eas:spatial>
+            <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+            <eas:polygon eas:scheme="degrees">
+                <eas:polygon-exterior>
+                    <eas:place>main triangle</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>52.08110</eas:x>
+                        <eas:y>4.34521</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.08071</eas:x>
+                        <eas:y>4.34422</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.07913</eas:x>
+                        <eas:y>4.34332</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.08110</eas:x>
+                        <eas:y>4.34521</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-exterior>
+                <eas:polygon-interior>
+                    <eas:place>hole1</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080450</eas:x>
+                        <eas:y>4.344323</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080357</eas:x>
+                        <eas:y>4.344110</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-interior>
+            </eas:polygon>
         </eas:spatial>
     </emd:coverage>
     <emd:rights>


### PR DESCRIPTION
part of EASY-1339

#### When applied it will
* Add `Polygon` classes (and other related classes) to support the new `<emd:polygon>` xml in https://github.com/DANS-KNAW/easy-schema/pull/37

@DANS-KNAW/easy for review

@lindareijnhoudt **_BEFORE MERGING THIS PR:_** first merge https://github.com/DANS-KNAW/easy-schema/pull/37 and publish the new schema. Then test whether all tests on this PR run (the currently don't, because they point to a schema that doesn't exist yet)!