### PR TITLE
fix bug with multiple eas:internal

### DIFF
--- a/src/main/config/Spatial-binding.xml
+++ b/src/main/config/Spatial-binding.xml
@@ -45,8 +45,8 @@
             <value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme" field="scheme" usage="optional"/>
             <value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="schemeId" field="schemeId" usage="optional"/>
             <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-exterior" field="exterior" type="nl.knaw.dans.pf.language.emd.types.PolygonPart" usage="optional"/>
-            <collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-interior" field="interior" factory="nl.knaw.dans.pf.language.emd.types.ListFactory.polygonPartList" usage="optional">
-                <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" type="nl.knaw.dans.pf.language.emd.types.PolygonPart" usage="optional"/>
+            <collection ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" field="interior" factory="nl.knaw.dans.pf.language.emd.types.ListFactory.polygonPartList" usage="optional">
+                <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="polygon-interior" type="nl.knaw.dans.pf.language.emd.types.PolygonPart" usage="optional"/>
             </collection>
         </structure>
 	</mapping>

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
@@ -154,7 +154,9 @@ public class EmdHelper {
                             "4.34422"), new PolygonPoint("52.07913", "4.34332"), new PolygonPoint("52.08110", "4.34521")));
                     PolygonPart interior1 = new PolygonPart("hole1", Arrays.asList(new PolygonPoint("52.080542", "4.344215"), new PolygonPoint("52.080450",
                             "4.344323"), new PolygonPoint("52.080357", "4.344110"), new PolygonPoint("52.080542", "4.344215")));
-                    Spatial.Polygon polygon = new Spatial.Polygon("POLYGON" + i, exterior, Collections.singletonList(interior1));
+                    PolygonPart interior2 = new PolygonPart("hole2", Arrays.asList(new PolygonPoint("52.080542", "4.344215"), new PolygonPoint("52.080450",
+                            "4.344323"), new PolygonPoint("52.080357", "4.344110"), new PolygonPoint("52.080542", "4.344215")));
+                    Spatial.Polygon polygon = new Spatial.Polygon("POLYGON" + i, exterior, Arrays.asList(interior1, interior2));
                     polygon.setSchemeId("polygon.bla" + 1);
                     spat.setPolygon(polygon);
                 }


### PR DESCRIPTION
@DANS-KNAW/easy for review

@janvanmansum @lindareijnhoudt I'm sorry, but can you do another release? Found a bug while implementing the crosswalker. The binding did not work correctly when multiple `internal`s are defined on one `Polygon`. Please merge/release https://github.com/DANS-KNAW/easy-schema/pull/42 before doing this one, though!