### PR TITLE
EASY-1330: add role to creator/contributor 

### DIFF
--- a/src/main/config/Author-binding.xml
+++ b/src/main/config/Author-binding.xml
@@ -31,7 +31,7 @@
 		<value ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="surname" field="surname" usage="optional" />
 		<value ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="organization" field="organization" usage="optional" />
 
-		<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="entityId" usage="optional">
+		<structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="entityId" field="entityIdHolder" usage="optional">
 			<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="identification-system"
 				field="identificationSystem" usage="optional" />
 			<value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme"
@@ -39,6 +39,10 @@
 			<value style="text" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" field="entityId" usage="optional" />
 		</structure>
 
+        <structure ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="role" field="role" usage="optional">
+            <value style="attribute" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" name="scheme" field="scheme" usage="optional" />
+            <value style="text" ns="http://easy.dans.knaw.nl/easy/easymetadata/eas/" field="role" usage="optional" />
+        </structure>
 	</mapping>
 
 </binding>

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
@@ -350,7 +350,7 @@ public class Author implements MetadataItem {
     // keep this for backwards compatibility
     public void setEntityId(final String entityId, final String scheme) {
         if (this.entityIdHolder == null) {
-            new EntityId(entityId, scheme, null);
+            this.entityIdHolder = new EntityId(entityId, scheme, null);
         } else {
             this.entityIdHolder.setEntityId(entityId);
             this.entityIdHolder.setScheme(scheme);

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
@@ -39,9 +39,13 @@ public class Author implements MetadataItem {
 
         public Role() {}
 
+        public Role(String role) {
+          this(role, "DATACITE");
+        }
+
         public Role(String role, String scheme) {
             this.role = role;
-            this.scheme = scheme;
+            this.setScheme(scheme);
         }
 
         public String getRole() {

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.pf.language.emd.types;
 
+import java.io.Serializable;
 import java.net.URI;
 
 import nl.knaw.dans.common.lang.id.DAI;
@@ -32,6 +33,78 @@ import org.apache.commons.lang.StringUtils;
  */
 public class Author implements MetadataItem {
 
+    public static class Role implements Serializable {
+        private String role;
+        private String scheme;
+
+        public Role() {}
+
+        public Role(String role, String scheme) {
+            this.role = role;
+            this.scheme = scheme;
+        }
+
+        public String getRole() {
+            return this.role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
+
+        public String getScheme() {
+            return this.scheme;
+        }
+
+        public void setScheme(String scheme) {
+            if ("DATACITE".equals(scheme))
+                this.scheme = scheme;
+            else
+                throw new IllegalArgumentException("The Author's role scheme can only be \"DATACITE\"");
+        }
+    }
+
+    public static class EntityId implements Serializable {
+
+        private String entityId;
+        private String scheme;
+        private URI identificationSystem;
+
+        public EntityId() {}
+
+        public EntityId(String entityId, String scheme, URI identificationSystem) {
+            this.entityId = entityId;
+            this.scheme = scheme;
+            this.identificationSystem = identificationSystem;
+        }
+
+        public String getEntityId() {
+            return this.entityId;
+        }
+
+        public void setEntityId(String entityId) {
+            this.entityId = entityId;
+            if (this.scheme == null)
+                this.scheme = DEFAULT_SCHEME;
+        }
+
+        public String getScheme() {
+            return this.scheme;
+        }
+
+        public void setScheme(String scheme) {
+            this.scheme = scheme;
+        }
+
+        public URI getIdentificationSystem() {
+            return this.identificationSystem;
+        }
+
+        public void setIdentificationSystem(URI identificationSystem) {
+            this.identificationSystem = identificationSystem;
+        }
+    }
+
     /**
      * The default identification system. {@value}
      */
@@ -47,9 +120,8 @@ public class Author implements MetadataItem {
     private String prefix;
     private String surname;
     private String organization;
-    private URI identificationSystem;
-    private String entityId;
-    private String scheme;
+    private EntityId entityIdHolder;
+    private Role role;
 
     /**
      * Constructs an Author.
@@ -85,7 +157,8 @@ public class Author implements MetadataItem {
     public String toString() {
         return (surname == null || "".equals(surname) ? "" : surname + ", ") + (title == null || "".equals(title) ? "" : title + " ")
                 + (initials == null || "".equals(initials) ? "" : initials) + (prefix == null || "".equals(prefix) ? "" : " " + prefix)
-                + (organization == null ? "" : hasPersonalEntries() ? " (" + organization + ")" : organization);
+                + (organization == null ? "" : hasPersonalEntries() ? " (" + organization + ")" : organization)
+                + (role == null || role.role == null || "".equals(role.role) ? "" : ", " + role.role);
     }
 
     /**
@@ -173,12 +246,34 @@ public class Author implements MetadataItem {
     }
 
     /**
+     * Get the entity id object of this author. This object includes the entity id, its identification system and scheme.
+     * 
+     * @return the entity id object of this author, may be <code>null</code>
+     */
+    public EntityId getEntityIdHolder() {
+        return this.entityIdHolder;
+    }
+
+    /**
+     * Set the entity id object of this author. If the scheme was not yet set, it is set to "DAI".
+     * 
+     * @param entityIdHolder
+     *        the entity id object of this author
+     */
+    public void setEntityIdHolder(EntityId entityIdHolder) {
+        this.entityIdHolder = entityIdHolder;
+        if (this.entityIdHolder.getScheme() == null)
+            this.entityIdHolder.setScheme(DEFAULT_SCHEME);
+    }
+
+    /**
      * Get the scheme by which this author is identified.
      * 
      * @return the scheme by which this author is identified
      */
+    // backwards compatible
     public String getScheme() {
-        return scheme;
+        return this.entityIdHolder.getScheme();
     }
 
     /**
@@ -187,8 +282,12 @@ public class Author implements MetadataItem {
      * @param scheme
      *        the scheme by which this author is identified
      */
+    // keep this for backwards compatibility
     public void setScheme(final String scheme) {
-        this.scheme = scheme;
+        if (this.entityIdHolder == null)
+            this.entityIdHolder = new EntityId(null, scheme, null);
+        else
+            this.entityIdHolder.setScheme(scheme);
     }
 
     /**
@@ -196,8 +295,9 @@ public class Author implements MetadataItem {
      * 
      * @return this author's identification system, may be <code>null</code>
      */
+    // keep this for backwards compatibility
     public URI getIdentificationSystem() {
-        return identificationSystem;
+        return this.entityIdHolder.getIdentificationSystem();
     }
 
     /**
@@ -206,8 +306,12 @@ public class Author implements MetadataItem {
      * @param identificationSystem
      *        this author's identification system, may be <code>null</code>
      */
+    // keep this for backwards compatibility
     public void setIdentificationSystem(final URI identificationSystem) {
-        this.identificationSystem = identificationSystem;
+        if (this.entityIdHolder == null)
+            this.entityIdHolder = new EntityId(null, null, identificationSystem);
+        else
+            this.entityIdHolder.setIdentificationSystem(identificationSystem);
     }
 
     /**
@@ -215,21 +319,20 @@ public class Author implements MetadataItem {
      * 
      * @return the entity id of this author, may be <code>null</code>
      */
+    // keep this for backwards compatibility
     public String getEntityId() {
-        return entityId;
+        return this.entityIdHolder.getEntityId();
     }
 
     /**
-     * Set the entity id of this author. If the scheme was not yet set, it is set to "DAI".
+     * Set the entity id of this author. The scheme is set to "DAI".
      * 
      * @param entityId
      *        the entity id of this author
      */
+    // keep this for backwards compatibility
     public void setEntityId(final String entityId) {
-        this.entityId = entityId;
-        if (scheme == null) {
-            scheme = DEFAULT_SCHEME;
-        }
+        this.entityIdHolder = new EntityId(entityId, DEFAULT_SCHEME, this.entityIdHolder == null ? null : this.entityIdHolder.getIdentificationSystem());
     }
 
     /**
@@ -240,9 +343,22 @@ public class Author implements MetadataItem {
      * @param scheme
      *        formal name of the identification system
      */
+    // keep this for backwards compatibility
     public void setEntityId(final String entityId, final String scheme) {
-        this.entityId = entityId;
-        this.scheme = scheme;
+        if (this.entityIdHolder == null) {
+            new EntityId(entityId, scheme, null);
+        } else {
+            this.entityIdHolder.setEntityId(entityId);
+            this.entityIdHolder.setScheme(scheme);
+        }
+    }
+
+    public Role getRole() {
+        return this.role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
     }
 
     public boolean isComplete() {
@@ -256,19 +372,19 @@ public class Author implements MetadataItem {
     }
 
     private boolean hasPersonalEntries() {
-        return StringUtils.isNotBlank(entityId) || StringUtils.isNotBlank(initials) || StringUtils.isNotBlank(prefix) || StringUtils.isNotBlank(surname)
-                || StringUtils.isNotBlank(title);
+        return (this.entityIdHolder != null && StringUtils.isNotBlank(this.entityIdHolder.getEntityId())) || StringUtils.isNotBlank(initials)
+                || StringUtils.isNotBlank(prefix) || StringUtils.isNotBlank(surname) || StringUtils.isNotBlank(title);
     }
 
     public boolean hasDigitalAuthorId() {
-        return EmdConstants.SCHEME_DAI.equals(scheme) && DAI.isValid(entityId);
+        return EmdConstants.SCHEME_DAI.equals(this.entityIdHolder.getScheme()) && DAI.isValid(this.entityIdHolder.getEntityId());
     }
 
     public DAI getDigitalAuthorId() {
         if (!hasDigitalAuthorId()) {
             return null;
         } else {
-            return new DAI(entityId);
+            return new DAI(this.entityIdHolder.getEntityId());
         }
     }
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
@@ -40,7 +40,7 @@ public class Author implements MetadataItem {
         public Role() {}
 
         public Role(String role) {
-          this(role, "DATACITE");
+            this(role, "DATACITE");
         }
 
         public Role(String role, String scheme) {

--- a/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/types/Author.java
@@ -277,6 +277,8 @@ public class Author implements MetadataItem {
      */
     // backwards compatible
     public String getScheme() {
+        if (this.entityIdHolder == null)
+            return null;
         return this.entityIdHolder.getScheme();
     }
 
@@ -301,6 +303,8 @@ public class Author implements MetadataItem {
      */
     // keep this for backwards compatibility
     public URI getIdentificationSystem() {
+        if (this.entityIdHolder == null)
+            return null;
         return this.entityIdHolder.getIdentificationSystem();
     }
 
@@ -325,6 +329,8 @@ public class Author implements MetadataItem {
      */
     // keep this for backwards compatibility
     public String getEntityId() {
+        if (this.entityIdHolder == null)
+            return null;
         return this.entityIdHolder.getEntityId();
     }
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
+++ b/src/main/java/nl/knaw/dans/pf/language/emd/validation/EMDValidator.java
@@ -38,7 +38,7 @@ public final class EMDValidator extends AbstractValidator {
      */
     public static final String VERSION_0_1 = "0.1";
 
-    public static final String SCHEMA_LOCATION = "http://easy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
+    public static final String SCHEMA_LOCATION = "http://deasy.dans.knaw.nl/schemas/md/emd/2017/09/emd.xsd";
 
     private static final EMDValidator instance = new EMDValidator();
 

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EmdCreatorTest.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EmdCreatorTest.java
@@ -15,18 +15,20 @@
  */
 package nl.knaw.dans.pf.language.emd;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import nl.knaw.dans.pf.language.emd.types.Author;
 import nl.knaw.dans.pf.language.emd.types.BasicString;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedList;
+import java.util.List;
 
 // ecco: CHECKSTYLE: OFF
 
 public class EmdCreatorTest {
+
     @Test
     public void testToStringWithSeparator() {
         EmdCreator emdc = new EmdCreator();
@@ -49,6 +51,25 @@ public class EmdCreatorTest {
     }
 
     @Test
+    public void testToStringAuthorWithRole() throws URISyntaxException {
+        Author author = new Author("Dr.", "A.B.C.", "van", "D.");
+        author.setOrganization("myOrg");
+        author.setEntityIdHolder(new Author.EntityId("12345", "scheme123", new URI("http://x")));
+        author.setRole(new Author.Role("RightsHolder", "DATACITE"));
+
+        Assert.assertEquals("D., Dr. A.B.C. van (myOrg), RightsHolder", author.toString());
+    }
+
+    @Test
+    public void testToStringOrganisationAuthorWithRole() throws URISyntaxException {
+        Author author = new Author();
+        author.setOrganization("myOrg");
+        author.setRole(new Author.Role("Sponsor", "DATACITE"));
+
+        Assert.assertEquals("myOrg, Sponsor", author.toString());
+    }
+
+    @Test
     public void testIsEmpty() {
         List<?> list = new LinkedList<Object>();
         Assert.assertTrue(list.isEmpty());
@@ -61,5 +82,4 @@ public class EmdCreatorTest {
         emdc.getDcCreator().add(null);
         Assert.assertFalse(emdc.isEmpty());
     }
-
 }

--- a/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
+++ b/src/test/java/nl/knaw/dans/pf/language/emd/EmdHelper.java
@@ -15,13 +15,6 @@
  */
 package nl.knaw.dans.pf.language.emd;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-
 import nl.knaw.dans.pf.language.emd.types.Author;
 import nl.knaw.dans.pf.language.emd.types.BasicDate;
 import nl.knaw.dans.pf.language.emd.types.BasicIdentifier;
@@ -32,11 +25,16 @@ import nl.knaw.dans.pf.language.emd.types.PolygonPart;
 import nl.knaw.dans.pf.language.emd.types.PolygonPoint;
 import nl.knaw.dans.pf.language.emd.types.Relation;
 import nl.knaw.dans.pf.language.emd.types.Spatial;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static nl.knaw.dans.pf.language.emd.types.ApplicationSpecific.PakbonStatus.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static nl.knaw.dans.pf.language.emd.types.ApplicationSpecific.PakbonStatus.IMPORTED;
 
 // ecco: CHECKSTYLE: OFF
 
@@ -90,13 +88,25 @@ public class EmdHelper {
         } else if (term.getType().equals(Author.class)) {
             for (int i = 0; i < times; i++) {
                 Author author = new Author();
-                author.setEntityId("123" + i);
-                author.setIdentificationSystem(new URI("http://author.org/sys" + i));
-                author.setInitials("abc");
-                author.setPrefix("van");
-                author.setSurname(term.getName().termName + " " + i);
-                author.setTitle("Dr.");
-                author.setOrganization("DANS");
+                if (i % 3 == 0) {
+                    author.setEntityIdHolder(new Author.EntityId("123" + i, null, new URI("http://author.org/sys" + i)));
+                    author.setInitials("abc");
+                    author.setPrefix("van");
+                    author.setSurname(term.getName().termName + " " + i);
+                    author.setTitle("Dr.");
+                } else if (i % 3 <= 1) {
+                    author.setIdentificationSystem(new URI("http://author.org/sys" + i));
+                    author.setEntityId("123" + i);
+                    author.setInitials("abc");
+                    author.setPrefix("van");
+                    author.setSurname(term.getName().termName + " " + i);
+                    author.setTitle("Dr.");
+                    author.setOrganization("DANS");
+                    author.setRole(new Author.Role("RightsHolder", "DATACITE"));
+                } else {
+                    author.setOrganization("DANS");
+                    author.setRole(new Author.Role("DataCollector", "DATACITE"));
+                }
                 list.add(author);
             }
         } else if (term.getType().equals(BasicDate.class)) {

--- a/src/test/resources/example1.xml
+++ b/src/test/resources/example1.xml
@@ -21,6 +21,7 @@
             <eas:surname>surname0</eas:surname>
             <eas:organization>organization0</eas:organization>
             <eas:entityId eas:identification-system="http://www.oxygenxml.com/" eas:scheme="DAI">entityId0</eas:entityId>
+            <eas:role eas:scheme="DATACITE">RelatedPerson</eas:role>
         </eas:creator>
         <eas:creator>
             <eas:title>title1</eas:title>
@@ -29,6 +30,13 @@
             <eas:surname>surname1</eas:surname>
             <eas:organization>organization1</eas:organization>
             <eas:entityId eas:identification-system="http://www.oxygenxml.com/" eas:scheme="DAI">entityId1</eas:entityId>
+        </eas:creator>
+        <eas:creator>
+            <eas:organization>organization2</eas:organization>
+            <eas:role eas:scheme="DATACITE">Sponsor</eas:role>
+        </eas:creator>
+        <eas:creator>
+            <eas:organization>organization3</eas:organization>
         </eas:creator>
     </emd:creator>
     <emd:subject>
@@ -65,6 +73,7 @@
             <eas:surname>surname3</eas:surname>
             <eas:organization>organization3</eas:organization>
             <eas:entityId eas:identification-system="http://www.oxygenxml.com/" eas:scheme="DAI">entityId3</eas:entityId>
+            <eas:role eas:scheme="DATACITE">Sponsor</eas:role>
         </eas:contributor>
     </emd:contributor>
     <emd:date>


### PR DESCRIPTION
part of EASY-1330

#### When applied it will
* add a role to the `Author` class. To avoid unnecessary empty `<role/>` or `<role></role>` elements, I had to wrap the `role` and `scheme` in an inner class to make this work.
* rewrite the implementation of `entityId` and its corresponding `identificationSystem` and `scheme`, such that unnecessary empty `<entityId/>` or `<entityId></entityId>` elements are no longer created. As with `role`, here an extra inner class was required. In order to support backwards compatibility, I left all the old methods and only changed their implementations according to the new subclass.

@DANS-KNAW/easy for review
@lindareijnhoudt, @janvanmansum I tested this PR with the latest `easy-schema` (https://github.com/DANS-KNAW/easy-schema/pull/47) that I deployed on deasy. Since (at the time of writing this) this new version of `easy-schema` is not yet published, this PR will most likely fail in Travis CI. **Before merging this PR, make sure you merged and published https://github.com/DANS-KNAW/easy-schema/pull/47. Also run the tests on this PR in Travis CI again to check whether everything is working as planned!**