### PR TITLE
Use jibx-run patched for DANS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 			<version>2.16</version>
 		</dependency>
         <dependency>
+            <groupId>nl.knaw.dans.easy</groupId>
+            <artifactId>easy-jibx-run</artifactId>
+            <version>1.2.4.5-DANS</version>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.7</version>


### PR DESCRIPTION
Fixes EASY-2099

- [ ] Test jibx-related code.

#### When applied it will
* Use [`easy-jibx-run`](https://github.com/DANS-KNAW/easy-jibx-run) instead of the regular `jibx-run`

#### Where should the reviewer @DANS-KNAW/easy start?

