### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
 	<artifactId>emd</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,14 @@
 	<name>EASY Metadata Library (EMD)</name>
     <inceptionYear>2014</inceptionYear>
     <version>3.9.1-SNAPSHOT</version>
+    <properties>
+        <easy.xml.version>2.16</easy.xml.version>
+        <dans-jibx.version>2.16</dans-jibx.version>
+        <commons-collections.version>20040616</commons-collections.version>
+        <maven-jibx-plugin.version>1.3.1</maven-jibx-plugin.version>
+        <jibx-bind.version>1.2.5</jibx-bind.version>
+        <bcel.version>6.0-DANS</bcel.version>
+    </properties>
     <scm>
         <!-- Attention project name != artifactId -->
         <developerConnection>scm:git:https://github.com/DANS-KNAW/easy-emd</developerConnection>
@@ -37,12 +45,12 @@
 		<dependency>
 			<groupId>nl.knaw.dans.easy</groupId>
 			<artifactId>xml</artifactId>
-			<version>2.16</version>
+			<version>${easy.xml.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>nl.knaw.dans.easy</groupId>
 			<artifactId>dans-jibx</artifactId>
-			<version>2.16</version>
+			<version>${dans-jibx.version}</version>
 		</dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -51,7 +59,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-            <version>20040616</version>
+            <version>${commons-collections.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -118,7 +126,7 @@
             <plugin>
                 <groupId>org.jibx</groupId>
                 <artifactId>maven-jibx-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>${maven-jibx-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -137,7 +145,7 @@
                     <dependency>
                         <groupId>org.jibx</groupId>
                         <artifactId>jibx-bind</artifactId>
-                        <version>1.2.5</version>
+                        <version>${jibx-bind.version}</version>
                         <scope>compile</scope>
                         <exclusions>
                             <exclusion>
@@ -149,7 +157,7 @@
                     <dependency>
                         <groupId>org.apache.bcel</groupId>
                         <artifactId>bcel</artifactId>
-                        <version>6.0-DANS</version>
+                        <version>${bcel.version}</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,33 +47,28 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.7</version>
         </dependency>
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>20040616</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-            <version>2.4</version>
 		</dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
         </dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-            <version>1.1.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-            <version>2.6</version>
 		</dependency>
 	</dependencies>
     <repositories>
@@ -123,7 +118,7 @@
             <plugin>
                 <groupId>org.jibx</groupId>
                 <artifactId>maven-jibx-plugin</artifactId>
-                <version>1.2.5</version>
+                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -168,7 +163,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
 	<artifactId>emd</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
 	<artifactId>emd</artifactId>


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* move unique dependency versions that aren't included in a parent POM to properties

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 